### PR TITLE
minimal changes for hardware rev 0.3 support

### DIFF
--- a/include/settings_hardware_specific.h
+++ b/include/settings_hardware_specific.h
@@ -7,14 +7,18 @@
 #endif
 
 #ifdef SEEED_XIAO
-#define UART2_TX_PIN 21
+#define UART2_TX_PIN 4
 #define UART2_RX_PIN 20
 #define LED_BLUE ((gpio_num_t)10)
-#define LED_RED_SUPL ((gpio_num_t)9)
-#define LED_RED ((gpio_num_t)8)
+#define LED_RED_SUPL (-1)
+#define LED_RED ((gpio_num_t)9)
 #define LED_OFF 1
 #define LED_ON 0
 #define ADC_BATTERY 0
+#define UART_INVERT_BITS (0) // (UART_SIGNAL_RXD_INV | UART_SIGNAL_TXD_INV)
+#define I2C_SCL_PIN ((gpio_num_t)7)
+#define I2C_SDA_PIN ((gpio_num_t)6)
+#define USB_DET_PIN ((gpio_num_t)3)
 #endif
 
 #ifdef LOLIN32_LITE

--- a/src/enter_deep_sleep.cpp
+++ b/src/enter_deep_sleep.cpp
@@ -30,9 +30,11 @@ void enter_deep_sleep()
     gpio_pullup_dis(LED_RED);
     gpio_pulldown_dis(LED_RED);
 
+#if LED_RED_SUPL > 0
     gpio_set_direction(LED_RED_SUPL, GPIO_MODE_INPUT);
     gpio_pullup_dis(LED_RED_SUPL);
     gpio_pulldown_dis(LED_RED_SUPL);
+#endif
 
 #ifndef SEEED_XIAO
     rtc_gpio_isolate(LED_BLUE);

--- a/src/kx_radio.cpp
+++ b/src/kx_radio.cpp
@@ -157,7 +157,7 @@ int KXRadio::connect()
     uart_param_config(UART_NUM, &uart_config);
     uart_set_pin(UART_NUM, UART2_TX_PIN, UART2_RX_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     // Invert UART2 TX and RX signals
-    uart_set_line_inverse(UART_NUM, UART_SIGNAL_RXD_INV | UART_SIGNAL_TXD_INV);
+    uart_set_line_inverse(UART_NUM, UART_INVERT_BITS);
 
     uint8_t buffer[256];
     while (true)

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -58,8 +58,12 @@ void setup()
     //  Turn on the board LED to indicate that we are starting up
     gpio_set_direction(LED_BLUE, GPIO_MODE_OUTPUT);
     gpio_set_direction(LED_RED, GPIO_MODE_OUTPUT);
+
+#if LED_RED_SUPL > 0
     gpio_set_direction(LED_RED_SUPL, GPIO_MODE_OUTPUT);
     gpio_set_level(LED_RED_SUPL, 1);
+#endif
+
     gpio_set_level(LED_BLUE, LED_ON);
     gpio_set_level(LED_RED, LED_ON);
 


### PR DESCRIPTION
@brianmathews @jeffkowalski these are the minimal changes required to support my rev 0.3 hardware (per the earlier schematic posted in slack).  The general changes are:

1. Moved the SOTAcat TX KX RX pin to GPIO4 to deconflict with the fsbl outputs
2. Removed the second control line for the red/amber LED
3. Added inverting hardware buffers, so the inversion is no longer required
4. Added a USB detection pin on GPIO3

These are the minimum to support out of the box. In addition, 

5. Added an I2C/SMBus battery monitor IC ( [MAX17260](https://www.analog.com/en/products/max17260.html)) using GPIO6 and GPIO7

How do we want to fold this in?  Should we add a separate PIO definition for these changes?  My next step is to start working on the driver for the MAX17260; I've already confirmed that it's responding on the I2C bus using the settings below.